### PR TITLE
fix echoes layerswitch

### DIFF
--- a/MP2/Structs/LayerSwitch.xml
+++ b/MP2/Structs/LayerSwitch.xml
@@ -4,7 +4,7 @@
         <Name>LayerSwitch</Name>
         <Atomic>true</Atomic>
         <SubProperties>
-            <Element Type="Asset" ID="0x0">
+            <Element Type="Int" ID="0x0">
                 <Name>Area ID</Name>
             </Element>
             <Element Type="Int" ID="0x1">


### PR DESCRIPTION
this is the internal area id, NOT the asset ID for the mrea
TODO: investigate whether this bug applies to prime/corruption